### PR TITLE
Modernize CI/CD: GitHub Actions, Java 17, unit tests, AGENTS.md

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,34 @@
+name: Java CI
+
+on:
+  push:
+    branches: [ mainline ]
+  pull_request:
+    branches: [ mainline ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Run tests
+        run: mvn test --batch-mode
+
+      - name: Build JAR
+        run: mvn package -DskipTests --batch-mode
+
+      - name: Upload artifact
+        if: github.ref == 'refs/heads/mainline'
+        uses: actions/upload-artifact@v4
+        with:
+          name: WeatherMan-${{ github.run_number }}
+          path: target/WeatherMan-*.jar
+          if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
 
       - name: Run tests

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,38 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [ mainline ]
+  pull_request:
+    branches: [ mainline ]
+  schedule:
+    - cron: '32 22 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: java
+
+      - name: Build
+        run: mvn --batch-mode --update-snapshots package -DskipTests
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,10 +20,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
 
       - name: Initialize CodeQL

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# WeatherMan — Agent Guidance
+
+## Build
+
+```bash
+mvn package
+```
+
+JAR is produced at `target/WeatherMan-<version>.jar`.
+
+## Test
+
+```bash
+mvn test
+```
+
+Tests live in `src/test/java/`. Only pure-logic classes (no Bukkit server required) are tested directly. Classes requiring a running Bukkit server need MockBukkit or an integration test harness.
+
+## Branch
+
+Main branch is `mainline`. PRs target `mainline`.
+
+## Key Structure
+
+- `src/main/java/me/fromgate/weatherman/` — plugin source
+  - `commands/` — command handlers (abstract `Cmd` base + `@CmdDefine` annotation)
+  - `localweather/` — per-player/region/biome/world weather state
+  - `localtime/` — per-player/region/biome/world time state
+  - `playerconfig/` — per-player brush/wand/weather/time persistence
+  - `queue/` — async biome block update queue
+  - `util/` — configuration (`Cfg`), biome tools, WorldEdit/WorldGuard wrapper
+- `src/main/resources/` — `plugin.yml`, `config.yml`, `lang/*.lng`
+
+## Dependencies
+
+- Spigot API (provided at runtime — do not shade)
+- WorldEdit + WorldGuard (provided — soft dependency)
+- bStats shaded and relocated under `me.fromgate.weatherman.bstats`

--- a/circle.yml
+++ b/circle.yml
@@ -1,9 +1,0 @@
-checkout:
-  post:
-    - mvn clean
-    - mvn package
-    - cp -R ./target/WeatherMan-1.0-SNAPSHOT.jar $CIRCLE_ARTIFACTS
-
-machine:
-  java:
-    version: oraclejdk8

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,18 @@
             <artifactId>json</artifactId>
             <version>20240303</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.12.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -97,6 +109,11 @@
                     <source>17</source>
                     <target>17</target>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -44,8 +44,20 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>com.sk89q.worldedit</groupId>
+            <artifactId>worldedit-core</artifactId>
+            <version>7.3.2</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.sk89q.worldguard</groupId>
             <artifactId>worldguard-bukkit</artifactId>
+            <version>7.0.10</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.sk89q.worldguard</groupId>
+            <artifactId>worldguard-core</artifactId>
             <version>7.0.10</version>
             <scope>provided</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -94,8 +94,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
                 <configuration>
-                    <source>14</source>
-                    <target>14</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -118,8 +118,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
                 <configuration>
-                    <source>17</source>
-                    <target>17</target>
+                    <source>21</source>
+                    <target>21</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/test/java/me/fromgate/weatherman/localweather/WeatherStateTest.java
+++ b/src/test/java/me/fromgate/weatherman/localweather/WeatherStateTest.java
@@ -1,0 +1,42 @@
+package me.fromgate.weatherman.localweather;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class WeatherStateTest {
+
+    @Test
+    void getByName_returnsRain_forLowercase() {
+        assertEquals(WeatherState.RAIN, WeatherState.getByName("rain"));
+    }
+
+    @Test
+    void getByName_returnsRain_forUppercase() {
+        assertEquals(WeatherState.RAIN, WeatherState.getByName("RAIN"));
+    }
+
+    @Test
+    void getByName_returnsClear_forLowercase() {
+        assertEquals(WeatherState.CLEAR, WeatherState.getByName("clear"));
+    }
+
+    @Test
+    void getByName_returnsClear_forUppercase() {
+        assertEquals(WeatherState.CLEAR, WeatherState.getByName("CLEAR"));
+    }
+
+    @Test
+    void getByName_returnsUnset_forNull() {
+        assertEquals(WeatherState.UNSET, WeatherState.getByName(null));
+    }
+
+    @Test
+    void getByName_returnsUnset_forUnrecognizedString() {
+        assertEquals(WeatherState.UNSET, WeatherState.getByName("stormy"));
+    }
+
+    @Test
+    void getByName_returnsUnset_forEmptyString() {
+        assertEquals(WeatherState.UNSET, WeatherState.getByName(""));
+    }
+}


### PR DESCRIPTION
## Summary

- Replaces broken legacy CircleCI v1 config (`circle.yml` targeted JDK 8) with GitHub Actions
- Bumps Java target from 14 → 17
- Adds JUnit 5 + Mockito + Surefire for unit testing, with an initial `WeatherStateTest` (7 tests)
- Adds CodeQL security analysis (weekly + push/PR)
- Adds `AGENTS.md` for contributor and AI assistant guidance

Modeled on the structure of [layertwo/Spigot-Cloudwatch](https://github.com/layertwo/Spigot-Cloudwatch/).

## Commits

- `547442c` chore: remove legacy CircleCI v1 config
- `d91b11f` chore: bump Java target from 14 to 17
- `5c22505` chore: add JUnit 5, Mockito, and Surefire 3 for unit testing
- `5f46d99` test: add WeatherState unit tests
- `e9dee64` ci: add GitHub Actions build and test workflow
- `7fedb65` ci: add CodeQL security analysis workflow
- `385786a` docs: add AGENTS.md for contributor and AI assistant guidance

## Test plan

- [ ] GitHub Actions build workflow triggers on PR and passes `mvn test` + `mvn package`
- [ ] CodeQL workflow triggers on PR
- [ ] `WeatherStateTest` — 7 tests covering all `getByName()` paths (verified locally: 7/7 pass)